### PR TITLE
Fix getting debugger file path when more than one match for the cartridge name is found in the local path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Getting debugger file path when more than one match for the cartridge name is found in the local path
+
 ## [2024.2.1] - 2025-03-04
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ pluginGroup = com.binarysushi
 pluginName = sfcc-studio
 pluginRepositoryUrl = https://github.com/nek4life/sfcc-studio
 # SemVer format -> https://semver.org
-pluginVersion = 2024.2.1
+pluginVersion = 2024.2.2
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 243

--- a/src/main/kotlin/com/binarysushi/studio/cartridges/CartridgePathUtil.kt
+++ b/src/main/kotlin/com/binarysushi/studio/cartridges/CartridgePathUtil.kt
@@ -60,7 +60,7 @@ class CartridgePathUtil {
          */
         fun getCartridgeRelativePathFromProjectRelativePath(cartridgeRootPath: String, localPath: String): String {
             val cartridgeName = CartridgePathUtil.getCartridgeNameFromRootPath(cartridgeRootPath)
-            val cartridgeNameIndex = localPath.indexOf(cartridgeName)
+            val cartridgeNameIndex = localPath.lastIndexOf(cartridgeName)
             return localPath.substring(cartridgeNameIndex).replace("\\", "/")
         }
 


### PR DESCRIPTION
This fixes an issue when the root folder has the same name as the cartridge name:
e.g. /**sfra_giftcert**/cartridges/**sfra_giftcert**/cartridge/controllers/CheckoutServices.js