### PR TITLE
Fix plugin settings display names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 
 - Getting debugger file path when more than one match for the cartridge name is found in the local path
+- Fix plugin settings display names
 
 ## [2024.2.1] - 2025-03-04
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -41,8 +41,8 @@
         <!-- Project Extensions -->
         <projectService serviceImplementation="com.binarysushi.studio.configuration.projectSettings.StudioConfigurationProvider"/>
 
-        <projectConfigurable id="SFCC_SERVER_CONFIGURABLE" groupId="tools" instance="com.binarysushi.studio.configuration.projectSettings.StudioServerConfigurable" displayName="%studio.configuration.server.panel.title"/>
-        <projectConfigurable id="SFCC_CARTRIDGE_CONFIGURABLE" groupId="tools" instance="com.binarysushi.studio.configuration.projectSettings.StudioCartridgeConfigurable" displayName="%studio.server.cartridges.panel.title"/>
+        <projectConfigurable id="SFCC_SERVER_CONFIGURABLE" groupId="tools" instance="com.binarysushi.studio.configuration.projectSettings.StudioServerConfigurable" key="studio.configuration.server.panel.title" bundle="messages.StudioBundle"/>
+        <projectConfigurable id="SFCC_CARTRIDGE_CONFIGURABLE" groupId="tools" instance="com.binarysushi.studio.configuration.projectSettings.StudioCartridgeConfigurable" key="studio.server.cartridges.panel.title" bundle="messages.StudioBundle"/>
 
         <!-- Module Extensions -->
         <moduleType id="SFCC_STUDIO_MODULE" implementationClass="com.binarysushi.studio.projectWizard.StudioModuleType"/>


### PR DESCRIPTION
The configuration names under File -> Settings -> Tools are now fixed and displayed correctly:
![image](https://github.com/user-attachments/assets/f5e4ebbd-a4bb-4c20-b317-5750058ffd61)


Source: https://plugins.jetbrains.com/docs/intellij/settings-guide.html#settings-declaration-attributes
